### PR TITLE
feat: replace redis settings with duckdb paths

### DIFF
--- a/flashduck/cli.py
+++ b/flashduck/cli.py
@@ -13,14 +13,19 @@ from .config import Config
 @click.group()
 @click.option('--table', default='default_table', help='Table name')
 @click.option('--db-root', default='./shared_db', help='Database root directory')
+@click.option('--cache-db', default=None, help='Path to DuckDB cache file')
+@click.option('--pending-writes', default=None,
+              help='Directory for pending Parquet writes')
 @click.option('--verbose', '-v', is_flag=True, help='Verbose logging')
 @click.pass_context
-def cli(ctx, table, db_root, verbose):
+def cli(ctx, table, db_root, cache_db, pending_writes, verbose):
     """FlashDuck CLI - High-performance data management with DuckDB"""
     # Create config
     config = Config(
         table_name=table,
         db_root=db_root,
+        cache_db_path=cache_db,
+        pending_writes_dir=pending_writes,
     )
     
     # Setup context

--- a/flashduck/config.py
+++ b/flashduck/config.py
@@ -14,6 +14,8 @@ class Config:
     # Core settings
     table_name: str = "default_table"
     db_root: str = "./shared_db"
+    cache_db_path: Optional[str] = None  # Path to DuckDB cache file
+    pending_writes_dir: Optional[str] = None  # Directory for incremental Parquet writes
     
     # Monitoring settings
     scan_interval_sec: int = 5
@@ -38,10 +40,15 @@ class Config:
         if self.table_primary_keys is None:
             self.table_primary_keys = {
                 "users": "id",
-                "products": "id", 
+                "products": "id",
                 "orders": "order_id",
                 "flights": "flight_unique_id"  # Will be auto-generated composite key
             }
+
+        if self.cache_db_path is None:
+            self.cache_db_path = os.path.join(self.db_root, "cache.duckdb")
+        if self.pending_writes_dir is None:
+            self.pending_writes_dir = os.path.join(self.db_root, "pending_writes")
     
     @classmethod
     def from_env(cls) -> 'Config':
@@ -49,6 +56,8 @@ class Config:
         return cls(
             table_name=os.getenv("TABLE", "default_table"),
             db_root=os.getenv("DB_ROOT", "./shared_db"),
+            cache_db_path=os.getenv("CACHE_DB_PATH"),
+            pending_writes_dir=os.getenv("PENDING_WRITES_DIR"),
             scan_interval_sec=int(os.getenv("SCAN_INTERVAL_SEC", "5")),
             snapshot_format=os.getenv("SNAPSHOT_FORMAT", "arrow"),
             parquet_compression=os.getenv("PARQUET_COMPRESSION", "zstd"),
@@ -70,3 +79,9 @@ class Config:
         
         if self.schema_evolution not in ["union", "strict"]:
             raise ValueError(f"Invalid schema_evolution: {self.schema_evolution}")
+
+        if not self.cache_db_path:
+            raise ValueError("cache_db_path must be set")
+
+        if not self.pending_writes_dir:
+            raise ValueError("pending_writes_dir must be set")

--- a/flashduck/duckdb_cache.py
+++ b/flashduck/duckdb_cache.py
@@ -16,7 +16,7 @@ class DuckDBCache:
 
     def __init__(self, config: Config, cache_db_path: Optional[str] = None):
         self.config = config
-        self.cache_db_path = cache_db_path or os.path.join(config.db_root, "cache.duckdb")
+        self.cache_db_path = cache_db_path or config.cache_db_path
         os.makedirs(os.path.dirname(self.cache_db_path), exist_ok=True)
 
         self.conn = duckdb.connect(self.cache_db_path)
@@ -54,8 +54,8 @@ class DuckDBCache:
         )
 
     def _write_pending(self, table_name: str, df: pd.DataFrame, op: str) -> str:
-        """Write changed rows to pending_writes/ directory as Parquet."""
-        pending_dir = os.path.join(self.config.db_root, "pending_writes")
+        """Write changed rows to the configured pending_writes_dir as Parquet."""
+        pending_dir = self.config.pending_writes_dir
         os.makedirs(pending_dir, exist_ok=True)
         filename = f"{table_name}_{int(time.time()*1000)}_{op}.parquet"
         path = os.path.join(pending_dir, filename)


### PR DESCRIPTION
## Summary
- add `cache_db_path` and `pending_writes_dir` options to config
- add CLI flags `--cache-db` and `--pending-writes`
- use the new config paths in `DuckDBCache`

## Testing
- `python -m py_compile flashduck/config.py flashduck/duckdb_cache.py flashduck/cli.py start_demo.py`
- `python -m flashduck.cli --help`

------
https://chatgpt.com/codex/tasks/task_e_68aab46f49ec83328a74af950cc6ce35