### PR TITLE
Use persistent read-only DuckDB connection for queries

### DIFF
--- a/flashduck/duckdb_cache.py
+++ b/flashduck/duckdb_cache.py
@@ -94,14 +94,6 @@ class DuckDBCache:
         rows = self.conn.execute("SELECT table_name FROM metadata").fetchall()
         return [r[0] for r in rows]
 
-    def get_all_tables(self) -> Dict[str, pd.DataFrame]:
-        tables: Dict[str, pd.DataFrame] = {}
-        for name in self.get_table_names():
-            df = self.load_table_snapshot(name)
-            if df is not None:
-                tables[name] = df
-        return tables
-
     def get_table_info(self, table_name: str) -> Dict[str, Any]:
         row = self.conn.execute(
             "SELECT row_count, columns, last_refresh FROM metadata WHERE table_name = ?",


### PR DESCRIPTION
## Summary
- Keep a single read-only DuckDB connection to the cache database
- Run SQL directly against cached tables without materializing DataFrames
- Drop unused `get_all_tables` helper from DuckDB cache

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aac99810b88332ab3e432549e4e0ac