### PR TITLE
refactor: derive primary keys dynamically

### DIFF
--- a/flashduck/core.py
+++ b/flashduck/core.py
@@ -43,22 +43,18 @@ class FlashDuckEngine:
         self._parquet_thread: Optional[threading.Thread] = None
         self._running = False
     
-    def start(self, create_sample_data: bool = False) -> None:
+    def start(self) -> None:
         """Start all background services"""
         if self._running:
             self.logger.warning("Engine already running")
             return
-        
+
         try:
             if not self.cache_manager.is_connected():
                 raise RuntimeError("Cannot access DuckDB cache")
 
             self.logger.info("Starting FlashDuck engine...")
-            
-            # Create sample data if requested
-            if create_sample_data:
-                self.file_monitor.create_sample_files()
-            
+
             # Start file monitoring
             self._monitor_thread = self.file_monitor.start_monitoring()
             

--- a/flashduck/duckdb_cache.py
+++ b/flashduck/duckdb_cache.py
@@ -62,6 +62,34 @@ class DuckDBCache:
         df.to_parquet(path, index=False)
         return path
 
+    def _resolve_pk(
+        self, table_name: str, df: Optional[pd.DataFrame] = None
+    ) -> Optional[str]:
+        """Resolve primary key using config or schema inspection."""
+        pk = self.config.table_primary_keys.get(table_name)
+        if isinstance(pk, (list, tuple)):
+            pk = pk[0] if pk else None
+        if pk:
+            return pk
+        columns: List[str] = []
+        if df is not None:
+            columns = df.columns.tolist()
+        else:
+            try:
+                columns = [
+                    c[1]
+                    for c in self.conn.execute(
+                        f"PRAGMA table_info('{table_name}')"
+                    ).fetchall()
+                ]
+            except Exception:
+                pass
+        if 'id' in columns:
+            return 'id'
+        if 'key' in columns:
+            return 'key'
+        return None
+
     # ------------------------------------------------------------------
     # Snapshot operations
     # ------------------------------------------------------------------
@@ -77,6 +105,57 @@ class DuckDBCache:
             len(df),
             len(df.columns),
         )
+
+    def store_ranked_table(
+        self, table_name: str, df: pd.DataFrame, primary_key: Optional[Any] = None
+    ) -> None:
+        """Store table and create ranked view ordered by _modified_time.
+
+        Supports both single and composite primary keys.
+        """
+        raw_table = f"{table_name}__raw"
+        self.conn.register("_df", df)
+        self.conn.execute(f"CREATE OR REPLACE TABLE {raw_table} AS SELECT * FROM _df")
+        self.conn.unregister("_df")
+
+        pk_cols: List[str] = []
+        if isinstance(primary_key, (list, tuple)):
+            pk_cols = [col for col in primary_key if col in df.columns]
+        elif isinstance(primary_key, str) and primary_key in df.columns:
+            pk_cols = [primary_key]
+
+        if pk_cols and "_modified_time" in df.columns:
+            partition_by = ", ".join(pk_cols)
+            self.conn.execute(
+                f"""
+                CREATE OR REPLACE VIEW {table_name} AS
+                SELECT * FROM (
+                    SELECT *,
+                           ROW_NUMBER() OVER (PARTITION BY {partition_by} ORDER BY _modified_time DESC) AS rn
+                    FROM {raw_table}
+                ) WHERE rn = 1
+                """
+            )
+        else:
+            # If primary key or _modified_time missing, expose raw table directly
+            self.conn.execute(
+                f"CREATE OR REPLACE VIEW {table_name} AS SELECT * FROM {raw_table}"
+            )
+
+        self._update_metadata(table_name)
+        self.logger.info(
+            "Stored ranked table '%s': %d rows, %d columns",
+            table_name,
+            len(df),
+            len(df.columns),
+        )
+
+    def remove_table(self, table_name: str) -> None:
+        """Drop view/table and remove metadata for a table."""
+        raw_table = f"{table_name}__raw"
+        self.conn.execute(f"DROP VIEW IF EXISTS {table_name}")
+        self.conn.execute(f"DROP TABLE IF EXISTS {raw_table}")
+        self.conn.execute("DELETE FROM metadata WHERE table_name = ?", [table_name])
 
     def store_snapshot(self, df: pd.DataFrame) -> None:
         self.store_table_snapshot(self.config.table_name, df)
@@ -118,9 +197,17 @@ class DuckDBCache:
     def get_snapshot_info(self) -> Dict[str, Any]:
         return self.get_table_info(self.config.table_name)
 
+    def get_all_table_info(self) -> Dict[str, Dict[str, Any]]:
+        info: Dict[str, Dict[str, Any]] = {}
+        for name in self.get_table_names():
+            info[name] = self.get_table_info(name)
+        return info
+
     def clear_cache(self) -> None:
         for name in self.get_table_names():
-            self.conn.execute(f"DROP TABLE IF EXISTS {name}")
+            raw_table = f"{name}__raw"
+            self.conn.execute(f"DROP VIEW IF EXISTS {name}")
+            self.conn.execute(f"DROP TABLE IF EXISTS {raw_table}")
         self.conn.execute("DELETE FROM metadata")
         self.logger.info("Cache cleared")
 
@@ -129,8 +216,10 @@ class DuckDBCache:
     # ------------------------------------------------------------------
     def enqueue_upsert(self, record_id: Any, data: Dict[str, Any]) -> str:
         table_name = self.config.table_name
-        pk = self.config.table_primary_keys.get(table_name, "id")
         df = pd.DataFrame([data])
+        pk = self._resolve_pk(table_name, df)
+        if not pk:
+            raise ValueError(f"Cannot determine primary key for table '{table_name}'")
         if pk not in df.columns:
             df[pk] = record_id
         record_id = df[pk].iloc[0]
@@ -148,7 +237,9 @@ class DuckDBCache:
 
     def enqueue_delete(self, record_id: Any) -> str:
         table_name = self.config.table_name
-        pk = self.config.table_primary_keys.get(table_name, "id")
+        pk = self._resolve_pk(table_name)
+        if not pk:
+            raise ValueError(f"Cannot determine primary key for table '{table_name}'")
         self.conn.execute(f"DELETE FROM {table_name} WHERE {pk} = ?", [record_id])
         self._update_metadata(table_name)
         df = pd.DataFrame([{pk: record_id}])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,5 @@ dependencies = [
     "setuptools>=80.9.0",
     "streamlit>=1.48.1",
     "watchdog>=6.0.0",
+    "pyyaml>=6.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "pandas>=1.3.0",
         "pyarrow>=8.0.0",
         "click>=8.0.0",
+        "pyyaml>=6.0",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
## Summary
- Load table primary key mapping solely from YAML without built-in table defaults
- Resolve primary keys from data (id/key) when unspecified and rank DuckDB views accordingly
- Remove sample data hooks and table-specific logic from file monitoring and engine startup

## Testing
- `python -m py_compile flashduck/config.py flashduck/duckdb_cache.py flashduck/file_monitor.py flashduck/query.py flashduck/core.py example/app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aab614acc48332b4d97292dcd88f4c