### PR TITLE
Remove Redis references and report DuckDB status

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,32 +3,30 @@
 
 ![FlashDuck Logo](https://via.placeholder.com/200x100/FF6B6B/FFFFFF?text=FlashDuck)
 
-**High-performance data management combining DuckDB and Redis**
+**High-performance data management powered by DuckDB**
 
-FlashDuck is a cutting-edge data management solution that combines the speed of Redis with the analytical power of DuckDB. It allows you to keep your data fresh and query it instantly, making it ideal for real-time applications and analytics.
+FlashDuck is a lightweight data management solution built on DuckDB. It keeps a local DuckDB cache synchronized with source files so you can query fresh data instantly—perfect for real-time applications and analytics.
 
-FlashDuck combines the in-memory speed of Redis with the analytical power of DuckDB, giving you a seamless way to synchronize data and query it instantly.
-
-Real-time sync: Folder-based or application-level changes are streamed into Redis, keeping your cache always current.
+Real-time sync: Folder-based or application-level changes are captured and reflected in the DuckDB cache.
 
 Single-file Parquet consolidation: Updates are automatically consolidated into a clean Parquet file for durability and downstream use.
 
-In-memory queries: DuckDB runs SQL directly against Redis-stored snapshots, so you get sub-second analytics without waiting for batch ETL.
+Embedded queries: DuckDB runs SQL directly against the cached tables for sub-second analytics without batch ETL.
 
-Lightweight & embeddable: Runs anywhere—no heavy cluster setup. Perfect for edge, cloud, or local development.
+Lightweight & embeddable: Runs anywhere—no external services or clusters required.
 
-Flexible integration: Use it as a cache, an analytics engine, or both. Ingest via Redis Streams, query with standard SQL, export with Parquet.
+Flexible integration: Use it as a cache, an analytics engine, or both. Ingest files, query with standard SQL, export with Parquet.
 
-FlashDuck is designed for developers, analysts, and teams who want the freshness of Redis and the analytical depth of DuckDB—without the overhead of a full data warehouse or lakehouse.
+FlashDuck is designed for developers and analysts who want the simplicity of DuckDB with automatic synchronization—without the overhead of a full data warehouse or lakehouse.
 
 ## 🚀 Features
 
 - **High-Performance Querying**: Execute SQL queries on cached data using DuckDB
 - **Real-time File Monitoring**: Automatic detection and processing of file changes
-- **Redis Caching**: Lightning-fast in-memory data access with configurable formats
+- **DuckDB Caching**: Persistent local cache with configurable formats
 - **Parquet Export**: Consolidated Parquet file generation with compression
 - **Schema Evolution**: Flexible handling of changing data structures
-- **Write Operations**: Queue-based upsert/delete operations via Redis Streams
+- **Write Operations**: Queue-based upsert/delete operations tracked via local Parquet files
 - **CLI Interface**: Command-line tools for common operations
 - **Streamlit Demo**: Interactive web interface showcasing all features
 

--- a/example/app.py
+++ b/example/app.py
@@ -56,9 +56,9 @@ def render_header():
     """Render application header"""
     st.title("🦆 FlashDuck Demo")
     st.markdown("""
-    **High-performance data management combining DuckDB and Redis**
-    
-    This demo showcases real-time file monitoring, Redis caching, SQL querying, and Parquet export capabilities.
+    **High-performance data management with DuckDB**
+
+    This demo showcases real-time file monitoring, DuckDB caching, SQL querying, and Parquet export capabilities.
     """)
 
 
@@ -136,23 +136,27 @@ def render_status_overview():
     status = engine.get_status()
     
     # Create metrics columns
-    col1, col2, col3 = st.columns(3)
-    
+    col1, col2, col3, col4 = st.columns(4)
+
     with col1:
         engine_status = status.get('engine', {})
         running = engine_status.get('running', False)
         st.metric(
-            "Engine Status", 
+            "Engine Status",
             "🟢 Running" if running else "🔴 Stopped",
             delta=None
         )
-    
+
+    cache_status = status.get('cache', {})
     with col2:
-        cache_status = status.get('cache', {})
         rows = cache_status.get('rows', 0)
         st.metric("Cache Rows", f"{rows:,}", delta=None)
-    
+
+    pending_status = status.get('pending_writes', {})
     with col3:
+        st.metric("Pending Writes", pending_status.get('count', 0), delta=None)
+
+    with col4:
         file_status = status.get('files', {})
         file_count = file_status.get('file_count', 0)
         st.metric("Files Monitored", file_count, delta=None)
@@ -162,18 +166,21 @@ def render_status_overview():
         
         # Cache details
         st.subheader("💾 Cache Status")
-        cache_cols = st.columns(3)
-        
+        cache_cols = st.columns(4)
+
         with cache_cols[0]:
+            st.write(f"**Connected:** {'Yes' if cache_status.get('connected') else 'No'}")
             st.write(f"**Rows:** {cache_status.get('rows', 0):,}")
-            st.write(f"**Columns:** {cache_status.get('columns', 0)}")
-        
+
         with cache_cols[1]:
+            st.write(f"**Columns:** {cache_status.get('columns', 0)}")
+
+        with cache_cols[2]:
             size_bytes = cache_status.get('size_bytes', 0)
             st.write(f"**Size:** {format_bytes(size_bytes)}")
             st.write(f"**Format:** {cache_status.get('format', 'N/A')}")
-        
-        with cache_cols[2]:
+
+        with cache_cols[3]:
             columns = cache_status.get('column_names', [])
             if columns:
                 st.write(f"**Columns:** {', '.join(columns[:5])}")
@@ -341,230 +348,104 @@ def render_data_explorer():
         st.error(f"Failed to load sample data: {sample_result.get('error', 'Unknown error')}")
 
 
+
+
 def render_sql_interface():
-    """Render SQL query interface with performance comparison"""
-    st.subheader("🗃️ SQL Interface with Performance Comparison")
-    
+    """Render SQL query interface"""
+    st.subheader("🗃️ SQL Interface")
+
     engine = get_engine()
     if not engine:
         st.error("FlashDuck engine not available")
         return
-    
-    st.info("💡 Compare performance between Redis cache queries and direct Parquet file queries with partitioned deduplication.")
-    
-    # Query mode selection
-    query_mode = st.radio(
-        "Select query execution mode:",
-        ["🏁 Performance Comparison", "🗄️ Redis Cache Only", "📁 Direct Parquet Only"],
-        key="sql_query_mode",
-        horizontal=True
-    )
-    
-    # Query input
+
     default_query = "SELECT * FROM users LIMIT 10"
-    
+
     sql_query = st.text_area(
         "Enter SQL Query:",
         value=st.session_state.get('sql_input', default_query),
         height=150,
         help="Enter a read-only SQL query. Only SELECT statements are allowed.",
-        key="sql_input"
+        key="sql_input",
     )
-    
-    # Pre-filled examples
+
     example_queries = [
         "SELECT * FROM users LIMIT 10",
         "SELECT name, age FROM users WHERE age > 25",
         "SELECT category, COUNT(*) as count FROM products GROUP BY category",
         "SELECT u.name, p.name as product_name, o.total FROM users u JOIN orders o ON u.id = o.user_id JOIN products p ON o.product_id = p.id",
         "SELECT status, COUNT(*) as order_count, AVG(total) as avg_total FROM orders GROUP BY status",
-        "SELECT * FROM products WHERE in_stock = true ORDER BY rating DESC"
+        "SELECT * FROM products WHERE in_stock = true ORDER BY rating DESC",
     ]
-    
+
     selected_example = st.selectbox(
         "Or choose an example query:",
         ["Custom Query"] + example_queries,
-        key="sql_example_selector"
+        key="sql_example_selector",
     )
-    
+
     if selected_example != "Custom Query":
         st.session_state.sql_input = selected_example
         st.rerun()
-    
-    # Query execution buttons
-    col1, col2, col3 = st.columns([2, 1, 1])
-    
+
+    col1, col2 = st.columns([1, 1])
     with col1:
         execute_button = st.button("🚀 Execute Query", use_container_width=True)
-    
     with col2:
-        validate_button = st.button("✅ Validate", use_container_width=True)
-    
-    with col3:
         clear_button = st.button("🧹 Clear", use_container_width=True)
-    
+
     if clear_button:
         st.session_state.sql_input = ""
         st.rerun()
-    
-    # Validate query
-    if validate_button:
-        try:
-            validation = engine.validate_query(sql_query)
-            if validation['valid']:
-                st.success("✅ Query is valid!")
-            else:
-                st.error(f"❌ Query validation failed: {validation['error']}")
-        except Exception as e:
-            st.error(f"❌ Validation error: {e}")
-    
-    # Execute query
+
     if execute_button:
         if not sql_query.strip():
             st.error("Please enter a SQL query")
             return
-        
+
         try:
-            if query_mode == "🏁 Performance Comparison":
-                # Run both queries and compare performance
-                st.write("**Performance Comparison Results:**")
-                
-                with st.spinner("Running performance comparison..."):
-                    # Execute Redis cache query
-                    import time
-                    start_time = time.time()
-                    cache_result = engine.query_engine.execute_sql(sql_query)
-                    cache_time = time.time() - start_time
-                    
-                    # Execute direct parquet query
-                    start_time = time.time()
-                    parquet_result = engine.query_engine.execute_sql_direct_parquet(sql_query, engine.config.db_root)
-                    parquet_time = time.time() - start_time
-                
-                # Performance comparison metrics
-                perf_cols = st.columns(4)
-                with perf_cols[0]:
-                    st.metric("🗄️ Redis Cache", f"{cache_time:.4f}s", delta=f"{cache_result.get('rows', 0)} rows")
-                with perf_cols[1]:
-                    st.metric("📁 Direct Parquet", f"{parquet_time:.4f}s", delta=f"{parquet_result.get('rows', 0)} rows")
-                with perf_cols[2]:
-                    if parquet_time > 0:
-                        speedup = cache_time / parquet_time if cache_time > parquet_time else parquet_time / cache_time
-                        winner = "Redis Cache" if cache_time < parquet_time else "Direct Parquet"
-                        st.metric("🏆 Winner", winner, delta=f"{speedup:.1f}x faster")
-                    else:
-                        st.metric("🏆 Winner", "Redis Cache", delta="N/A")
-                with perf_cols[3]:
-                    cache_success = cache_result.get("success", False)
-                    parquet_success = parquet_result.get("success", False)
-                    both_success = cache_success and parquet_success
-                    st.metric("✅ Results Match", "Yes" if both_success else "No", delta="Both succeeded" if both_success else "Check errors")
-                
-                # Show results from cache (they should be the same)
-                if cache_result.get("success", False):
-                    st.success(f"✅ Query executed successfully! ({cache_result['rows']} rows returned)")
-                    
-                    if cache_result["rows"] > 0 and cache_result.get("data"):
-                        df = pd.DataFrame(cache_result["data"])
-                        st.dataframe(df, use_container_width=True)
-                        
-                        # Download options
-                        col1, col2 = st.columns(2)
-                        with col1:
-                            csv_data = df.to_csv(index=False)
-                            st.download_button("📥 Download CSV", csv_data, "query_results.csv", "text/csv", use_container_width=True)
-                        with col2:
-                            json_data = df.to_json(orient='records', indent=2)
-                            st.download_button("📥 Download JSON", json_data, "query_results.json", "application/json", use_container_width=True)
-                    else:
-                        st.info("Query executed successfully but returned no rows")
+            with st.spinner("Executing query..."):
+                result = engine.sql(sql_query)
+            if result.get("success", False):
+                st.success(f"✅ Query executed! ({result['rows']} rows returned)")
+
+                if result["rows"] > 0 and result.get("data"):
+                    df = pd.DataFrame(result["data"])
+                    st.dataframe(df, use_container_width=True)
+
+                    col1, col2 = st.columns(2)
+                    with col1:
+                        csv_data = df.to_csv(index=False)
+                        st.download_button("📥 Download CSV", csv_data, "query_results.csv", "text/csv", use_container_width=True)
+                    with col2:
+                        json_data = df.to_json(orient="records", indent=2)
+                        st.download_button("📥 Download JSON", json_data, "query_results.json", "application/json", use_container_width=True)
                 else:
-                    st.error(f"❌ Cache query failed: {cache_result.get('error', 'Unknown error')}")
-                    
-                if not parquet_result.get("success", False):
-                    st.error(f"❌ Parquet query failed: {parquet_result.get('error', 'Unknown error')}")
-                    
-            elif query_mode == "🗄️ Redis Cache Only":
-                # Execute only Redis cache query
-                with st.spinner("Executing Redis cache query..."):
-                    result = engine.query_engine.execute_sql(sql_query)
-                
-                if result.get("success", False):
-                    st.success(f"✅ Redis Cache query executed! ({result['rows']} rows returned)")
-                    
-                    if result["rows"] > 0 and result.get("data"):
-                        df = pd.DataFrame(result["data"])
-                        st.dataframe(df, use_container_width=True)
-                        
-                        # Download options
-                        col1, col2 = st.columns(2)
-                        with col1:
-                            csv_data = df.to_csv(index=False)
-                            st.download_button("📥 Download CSV", csv_data, "query_results.csv", "text/csv", use_container_width=True)
-                        with col2:
-                            json_data = df.to_json(orient='records', indent=2)
-                            st.download_button("📥 Download JSON", json_data, "query_results.json", "application/json", use_container_width=True)
-                    else:
-                        st.info("Query executed successfully but returned no rows")
-                else:
-                    st.error(f"❌ Query failed: {result.get('error', 'Unknown error')}")
-                    
-            elif query_mode == "📁 Direct Parquet Only":
-                # Execute only direct parquet query
-                with st.spinner("Executing direct Parquet query..."):
-                    result = engine.query_engine.execute_sql_direct_parquet(sql_query, engine.config.db_root)
-                
-                if result.get("success", False):
-                    query_time = result.get("query_time", 0)
-                    st.success(f"✅ Direct Parquet query executed in {query_time:.4f}s! ({result['rows']} rows returned)")
-                    
-                    if result["rows"] > 0 and result.get("data"):
-                        df = pd.DataFrame(result["data"])
-                        st.dataframe(df, use_container_width=True)
-                        
-                        # Download options
-                        col1, col2 = st.columns(2)
-                        with col1:
-                            csv_data = df.to_csv(index=False)
-                            st.download_button("📥 Download CSV", csv_data, "query_results.csv", "text/csv", use_container_width=True)
-                        with col2:
-                            json_data = df.to_json(orient='records', indent=2)
-                            st.download_button("📥 Download JSON", json_data, "query_results.json", "application/json", use_container_width=True)
-                    else:
-                        st.info("Query executed successfully but returned no rows")
-                else:
-                    st.error(f"❌ Query failed: {result.get('error', 'Unknown error')}")
-                    
+                    st.info("Query executed successfully but returned no rows")
+            else:
+                st.error(f"❌ Query failed: {result.get('error', 'Unknown error')}")
         except Exception as e:
             st.error(f"❌ Error executing query: {e}")
-    
-    # Query examples section
-    with st.expander("💡 Query Examples & Tips", expanded=False):
+
+    with st.expander("💡 Query Examples", expanded=False):
         st.write("**Example Queries:**")
-        
+
         examples = [
             ("Basic Selection", "SELECT * FROM users WHERE active = true"),
             ("Aggregation", "SELECT category, COUNT(*) as count, AVG(price) as avg_price FROM products GROUP BY category"),
             ("Join Query", "SELECT u.name, o.total, p.name as product FROM users u JOIN orders o ON u.id = o.user_id JOIN products p ON o.product_id = p.id"),
             ("Window Function", "SELECT name, age, RANK() OVER (ORDER BY age DESC) as age_rank FROM users"),
             ("Date Filtering", "SELECT * FROM orders WHERE date >= '2025-01-01'"),
-            ("Complex Analytics", "WITH user_stats AS (SELECT user_id, COUNT(*) as order_count, SUM(total) as total_spent FROM orders GROUP BY user_id) SELECT u.name, us.order_count, us.total_spent FROM users u JOIN user_stats us ON u.id = us.user_id ORDER BY us.total_spent DESC")
+            ("Complex Analytics", "WITH user_stats AS (SELECT user_id, COUNT(*) as order_count, SUM(total) as total_spent FROM orders GROUP BY user_id) SELECT u.name, us.order_count, us.total_spent FROM users u JOIN user_stats us ON u.id = us.user_id ORDER BY us.total_spent DESC"),
         ]
-        
+
         for title, query in examples:
             with st.container():
                 st.write(f"**{title}:**")
-                if st.button(f"Use this query", key=f"example_{title.replace(' ', '_').lower()}"):
+                if st.button("Use this query", key=f"example_{title.replace(' ', '_').lower()}"):
                     st.session_state.sql_input = query
                     st.rerun()
             st.code(query, language="sql")
-        
-        st.divider()
-        st.write("**Performance Tips:**")
-        st.write("• **Redis Cache**: Fast for repeated queries, data already in memory")  
-        st.write("• **Direct Parquet**: Uses ranked window functions for deduplication, may be slower but always current")
-        st.write("• **Partitioned Files**: Each update creates a new partition file with timestamp")
-        st.write("• **Primary Key Ranking**: Latest records selected by _modified_time for each primary key")
 
 
 def render_write_operations():
@@ -1112,7 +993,7 @@ def main():
     st.divider()
     st.markdown("""
     <div style='text-align: center; color: #666; font-size: 0.8em;'>
-        🦆 FlashDuck v0.1.0 - High-performance data management with DuckDB and Redis
+        🦆 FlashDuck v0.1.0 - High-performance data management with DuckDB
     </div>
     """, unsafe_allow_html=True)
 

--- a/flashduck/cli.py
+++ b/flashduck/cli.py
@@ -117,14 +117,20 @@ def status(ctx):
         click.echo(f"Engine Running: {'✅' if engine_status.get('running') else '❌'}")
         click.echo(f"Table Name: {engine_status.get('table_name', 'N/A')}")
         click.echo(f"DB Root: {engine_status.get('db_root', 'N/A')}")
-        
+
         # Cache status
         cache_status = status.get('cache', {})
         if cache_status:
+            click.echo(f"DuckDB Connected: {'✅' if cache_status.get('connected') else '❌'}")
             click.echo(f"Cache Rows: {cache_status.get('rows', 0):,}")
             click.echo(f"Cache Columns: {cache_status.get('columns', 0)}")
             click.echo(f"Cache Size: {cache_status.get('size_bytes', 0):,} bytes")
-        
+
+        # Pending writes status
+        pending_status = status.get('pending_writes', {})
+        if pending_status:
+            click.echo(f"Pending Writes: {pending_status.get('count', 0)}")
+
         # File status
         file_status = status.get('files', {})
         click.echo(f"Files Monitored: {file_status.get('file_count', 0)}")

--- a/flashduck/core.py
+++ b/flashduck/core.py
@@ -105,21 +105,29 @@ class FlashDuckEngine:
     def get_status(self) -> Dict[str, Any]:
         """Get comprehensive engine status"""
         try:
+            pending = self.cache_manager.list_pending_writes()
             return {
                 "engine": {
                     "running": self._running,
                     "table_name": self.config.table_name,
-                    "db_root": self.config.db_root
+                    "db_root": self.config.db_root,
                 },
-                "cache": self.cache_manager.get_snapshot_info(),
+                "cache": {
+                    "connected": self.cache_manager.is_connected(),
+                    **self.cache_manager.get_snapshot_info(),
+                },
+                "pending_writes": {
+                    "count": len(pending),
+                    "files": pending,
+                },
                 "files": self.file_monitor.get_file_info(),
                 "parquet": self.parquet_writer.get_parquet_info(),
                 "config": {
                     "scan_interval_sec": self.config.scan_interval_sec,
                     "snapshot_format": self.config.snapshot_format,
                     "parquet_compression": self.config.parquet_compression,
-                    "schema_evolution": self.config.schema_evolution
-                }
+                    "schema_evolution": self.config.schema_evolution,
+                },
             }
         except Exception as e:
             self.logger.error(f"Failed to get status: {e}")


### PR DESCRIPTION
## Summary
- replace Redis-centric docs and UI with DuckDB cache descriptions
- enhance engine status to report DuckDB connectivity and pending writes
- streamline SQL interface and status overview in demo app

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aacd5587b483329c82d9c0097fb68f