### PR TITLE
Add tests for validate_sql_readonly and DuckDB ACID behavior

### DIFF
--- a/tests/test_acid_concurrency.py
+++ b/tests/test_acid_concurrency.py
@@ -1,0 +1,92 @@
+import threading
+import time
+
+import duckdb
+import pytest
+
+
+def test_atomicity_transaction_rollback(tmp_path):
+    db = tmp_path / "atomic.db"
+    conn = duckdb.connect(str(db))
+    conn.execute("CREATE TABLE items (id INTEGER)")
+    conn.begin()
+    conn.execute("INSERT INTO items VALUES (1)")
+    with pytest.raises(duckdb.ConversionException):
+        conn.execute("INSERT INTO items VALUES ('a')")
+    conn.rollback()
+    count = conn.execute("SELECT COUNT(*) FROM items").fetchone()[0]
+    assert count == 0
+    conn.close()
+
+
+def test_isolation_between_transactions(tmp_path):
+    db = tmp_path / "isolation.db"
+    conn1 = duckdb.connect(str(db))
+    conn2 = duckdb.connect(str(db))
+    conn1.execute("CREATE TABLE items (id INTEGER)")
+    conn1.commit()
+    conn1.begin()
+    conn1.execute("INSERT INTO items VALUES (1)")
+    count_before = conn2.execute("SELECT COUNT(*) FROM items").fetchone()[0]
+    assert count_before == 0
+    conn1.commit()
+    count_after = conn2.execute("SELECT COUNT(*) FROM items").fetchone()[0]
+    assert count_after == 1
+    conn1.close()
+    conn2.close()
+
+
+def test_durability_after_commit(tmp_path):
+    db = tmp_path / "durability.db"
+    conn = duckdb.connect(str(db))
+    conn.execute("CREATE TABLE items (id INTEGER)")
+    conn.execute("INSERT INTO items VALUES (1)")
+    conn.commit()
+    conn.close()
+    conn2 = duckdb.connect(str(db))
+    count = conn2.execute("SELECT COUNT(*) FROM items").fetchone()[0]
+    assert count == 1
+    conn2.close()
+
+
+def test_concurrent_read_write(tmp_path):
+    db = tmp_path / "concurrent.db"
+    conn_init = duckdb.connect(str(db))
+    conn_init.execute("CREATE TABLE items (id INTEGER)")
+    conn_init.commit()
+    conn_init.close()
+
+    total_rows = 50
+    done = threading.Event()
+
+    def writer():
+        conn_w = duckdb.connect(str(db))
+        for i in range(total_rows):
+            conn_w.execute("INSERT INTO items VALUES (?)", (i,))
+            conn_w.commit()
+            time.sleep(0.005)
+        conn_w.close()
+        done.set()
+
+    read_counts = []
+
+    def reader():
+        conn_r = duckdb.connect(str(db))
+        while not done.is_set():
+            read_counts.append(conn_r.execute("SELECT COUNT(*) FROM items").fetchone()[0])
+            time.sleep(0.005)
+        conn_r.close()
+
+    t_writer = threading.Thread(target=writer)
+    t_reader = threading.Thread(target=reader)
+    t_writer.start()
+    t_reader.start()
+    t_writer.join()
+    done.set()
+    t_reader.join()
+
+    conn_v = duckdb.connect(str(db))
+    final_count = conn_v.execute("SELECT COUNT(*) FROM items").fetchone()[0]
+    conn_v.close()
+    assert final_count == total_rows
+    assert read_counts and read_counts[-1] == total_rows

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,28 @@
+import ast
+from pathlib import Path
+
+import pytest
+
+# Extract the validate_sql_readonly function definition from the source file
+# without importing its module (which requires heavy optional dependencies).
+source_path = Path(__file__).resolve().parent.parent / "flashduck" / "utils.py"
+source = source_path.read_text()
+module = ast.parse(source)
+func_node = next(
+    node for node in module.body if isinstance(node, ast.FunctionDef) and node.name == "validate_sql_readonly"
+)
+func_code = ast.get_source_segment(source, func_node)
+namespace = {}
+exec(func_code, namespace)
+validate_sql_readonly = namespace["validate_sql_readonly"]
+
+
+def test_validate_sql_readonly_allows_select():
+    """SELECT statements should be allowed."""
+    assert validate_sql_readonly("SELECT 1") is None
+
+
+def test_validate_sql_readonly_rejects_delete():
+    """DELETE statements should raise an error."""
+    with pytest.raises(ValueError):
+        validate_sql_readonly("DELETE FROM t")


### PR DESCRIPTION
## Summary
- add tests to ensure read-only SELECT queries pass validation
- verify DELETE queries trigger ValueError
- add ACID and concurrency tests for DuckDB operations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aae93567b08332a0973a644d9545e4