### PR TITLE
chore: require modern duckdb and pandas

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ Flexible integration: Use it as a cache, an analytics engine, or both. Ingest fi
 
 FlashDuck is designed for developers and analysts who want the simplicity of DuckDB with automatic synchronization—without the overhead of a full data warehouse or lakehouse.
 
+## Requirements
+
+- Python 3.8 or later
+- DuckDB 1.0 or later
+- Pandas 2.0 or later
+- PyArrow 8.0 or later
+
 ## 🚀 Features
 
 - **High-Performance Querying**: Execute SQL queries on cached data using DuckDB

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,13 @@ version = "0.1.0"
 description = "Add your description here"
 requires-python = ">=3.8"
 dependencies = [
-    "duckdb>=0.8,<0.10",
-    "pandas>=1.3,<2.1",
+    "duckdb>=1.0",
+    "pandas>=2.0",
     "plotly>=5.0.0",
     "pyarrow>=8.0.0",
     "setuptools>=65.0",
     "streamlit>=1.28.0",
     "watchdog>=2.1.0",
     "pyyaml>=6.0",
+    "click>=8.0.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-duckdb>=1.3.2
-pandas>=2.3.2
-plotly>=6.3.0
-pyarrow>=21.0.0
-setuptools>=80.9.0
-streamlit>=1.48.1
-watchdog>=6.0.0
+duckdb>=1.0.0
+pandas>=2.0.0
+plotly>=5.0.0
+pyarrow>=8.0.0
+setuptools>=65.0
+streamlit>=1.28.0
+watchdog>=2.1.0
 pyyaml>=6.0
 click>=8.0.0


### PR DESCRIPTION
## Summary
- require DuckDB>=1.0 and pandas>=2.0 in project metadata
- document Python 3.8+ and new minimum dependencies
- align pyarrow, plotly, streamlit and other versions with Python 3.8 availability

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abced75a508332ae44f2e507e2768c