### PR TITLE
Pin duckdb for Python 3.8 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ FlashDuck is designed for developers and analysts who want the simplicity of Duc
 ## Requirements
 
 - Python 3.8 or later
-- DuckDB 1.0 or later
+- DuckDB 1.0.x (pinned below 1.1 for Python 3.8 compatibility)
 - Pandas 2.0 or later
 - PyArrow 8.0 or later
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Add your description here"
 requires-python = ">=3.8"
 dependencies = [
-    "duckdb>=1.0",
+    "duckdb>=1.0,<1.1",
     "pandas>=2.0",
     "plotly>=5.0.0",
     "pyarrow>=8.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-duckdb>=1.0.0
+duckdb>=1.0.0,<1.1.0
 pandas>=2.0.0
 plotly>=5.0.0
 pyarrow>=8.0.0

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     ],
     python_requires=">=3.8",
     install_requires=[
-        "duckdb>=0.8,<0.10",
+        "duckdb>=1.0,<1.1",
         "pandas>=1.3,<2.1",
         "pyarrow>=8.0.0",
         "click>=8.0.0",


### PR DESCRIPTION
## Summary
- pin duckdb to 1.0.x so Python 3.8 can install a pre-built wheel instead of compiling from source
- document DuckDB pin in README

## Testing
- `python -m flake8` *(fails: many lint errors)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae1f52b298833287aa22307e7ae127