### PR TITLE
Add S3 sync manager and configuration

### DIFF
--- a/flashduck/__init__.py
+++ b/flashduck/__init__.py
@@ -8,6 +8,7 @@ from .file_monitor import FileMonitor
 from .config import Config
 from .sync_base import SyncBase
 from .smb_sync_manager import SMBSyncManager
+from .s3_sync import S3SyncManager
 
 __version__ = "0.1.0"
 __author__ = "FlashDuck Contributors"
@@ -22,4 +23,5 @@ __all__ = [
     "Config",
     "SyncBase",
     "SMBSyncManager",
+    "S3SyncManager",
 ]

--- a/flashduck/config.py
+++ b/flashduck/config.py
@@ -37,6 +37,13 @@ class Config:
     
     # Schema evolution
     schema_evolution: str = "union"  # union, strict
+
+    # S3 settings
+    s3_bucket: Optional[str] = None
+    s3_region: Optional[str] = None
+    aws_access_key_id: Optional[str] = None
+    aws_secret_access_key: Optional[str] = None
+    aws_session_token: Optional[str] = None
     
     def __post_init__(self):
         """Set default values after initialization"""
@@ -86,6 +93,11 @@ class Config:
             sql_output_format=os.getenv("SQL_OUTPUT_FORMAT", "json"),
             schema_evolution=os.getenv("SCHEMA_EVOLUTION", "union"),
             table_config_path=os.getenv("TABLE_CONFIG_PATH"),
+            s3_bucket=os.getenv("S3_BUCKET"),
+            s3_region=os.getenv("S3_REGION"),
+            aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+            aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
+            aws_session_token=os.getenv("AWS_SESSION_TOKEN"),
         )
     
     def validate(self) -> None:
@@ -104,3 +116,7 @@ class Config:
 
         if not self.pending_writes_dir:
             raise ValueError("pending_writes_dir must be set")
+
+        if self.s3_bucket and not self.s3_region:
+            # region can be optional; but if not provided, boto3 chooses default.
+            pass

--- a/flashduck/s3_sync.py
+++ b/flashduck/s3_sync.py
@@ -1,0 +1,146 @@
+"""S3 implementation of the SyncBase interface."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Set, Optional
+
+import boto3
+
+from .sync_base import SyncBase
+from .config import Config
+
+
+class S3SyncManager(SyncBase):
+    """Synchronize local files with an S3 bucket.
+
+    This implementation performs a one-shot synchronization when ``start``
+    is called. It uploads files from the ``pending_writes_dir`` to the
+    configured bucket, downloads any objects present in S3 but missing
+    locally, and removes local files that no longer exist in the bucket.
+    """
+
+    def __init__(self, config: Config) -> None:
+        self.config = config
+        self._running = False
+        self._upload_info: Dict[str, Any] = {}
+        self._download_info: Dict[str, Any] = {}
+        self.s3 = boto3.client(
+            "s3",
+            aws_access_key_id=config.aws_access_key_id,
+            aws_secret_access_key=config.aws_secret_access_key,
+            aws_session_token=config.aws_session_token,
+            region_name=config.s3_region,
+        )
+
+    # SyncBase interface -------------------------------------------------
+    def start(self) -> None:  # pragma: no cover - thin wrapper
+        """Run a single synchronization cycle and mark as running."""
+        self._running = True
+        self.sync_once()
+
+    def stop(self) -> None:  # pragma: no cover - thin wrapper
+        """Mark the manager as stopped."""
+        self._running = False
+
+    def upload_status(self) -> Dict[str, Any]:
+        return {"running": self._running, **self._upload_info}
+
+    def download_status(self) -> Dict[str, Any]:
+        return {"running": self._running, **self._download_info}
+
+    # Internal helpers ---------------------------------------------------
+    def sync_once(self) -> None:
+        """Perform a single sync cycle."""
+        bucket = self.config.s3_bucket
+        if not bucket:
+            raise ValueError("s3_bucket must be configured")
+
+        s3_objects = set(self._list_bucket_objects(bucket))
+        uploaded = self._upload_pending(bucket)
+        local_files = self._list_local_files()
+        downloaded = self._download_missing(bucket, s3_objects, local_files)
+        deleted = self._delete_stale(local_files, s3_objects)
+        self._upload_info = {"uploaded": uploaded}
+        self._download_info = {"downloaded": downloaded, "deleted": deleted}
+
+    def _list_bucket_objects(self, bucket: str) -> List[str]:
+        """Return all object keys in the bucket."""
+        keys: List[str] = []
+        token = None
+        while True:
+            params = {"Bucket": bucket}
+            if token:
+                params["ContinuationToken"] = token
+            resp = self.s3.list_objects_v2(**params)
+            for obj in resp.get("Contents", []):
+                keys.append(obj["Key"])
+            if resp.get("IsTruncated"):
+                token = resp.get("NextContinuationToken")
+            else:
+                break
+        return keys
+
+    def _upload_pending(self, bucket: str) -> List[str]:
+        uploaded: List[str] = []
+        pending_dir = self.config.pending_writes_dir
+        if not pending_dir or not os.path.isdir(pending_dir):
+            return uploaded
+        for root, _, files in os.walk(pending_dir):
+            for name in files:
+                local_path = os.path.join(root, name)
+                key = os.path.relpath(local_path, pending_dir)
+                with open(local_path, "rb") as f:
+                    self.s3.put_object(Bucket=bucket, Key=key, Body=f)
+                uploaded.append(key)
+        return uploaded
+
+    def _list_local_files(self) -> Set[str]:
+        """List relative file paths in db_root excluding pending writes."""
+        local: Set[str] = set()
+        base = self.config.db_root
+        pending_dir = self.config.pending_writes_dir
+        pending_rel: Optional[str] = None
+        if pending_dir:
+            try:
+                pending_rel = os.path.relpath(pending_dir, base)
+            except ValueError:
+                pending_rel = None
+        for root, _, files in os.walk(base):
+            for name in files:
+                full = os.path.join(root, name)
+                rel = os.path.relpath(full, base)
+                if pending_rel and rel.startswith(pending_rel):
+                    continue
+                local.add(rel)
+        return local
+
+    def _download_missing(
+        self, bucket: str, s3_objects: Set[str], local_files: Set[str]
+    ) -> List[str]:
+        downloaded: List[str] = []
+        base = self.config.db_root
+        for key in s3_objects:
+            if key in local_files:
+                continue
+            dest = os.path.join(base, key)
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            obj = self.s3.get_object(Bucket=bucket, Key=key)
+            body = obj["Body"].read()
+            with open(dest, "wb") as f:
+                f.write(body)
+            downloaded.append(key)
+        return downloaded
+
+    def _delete_stale(
+        self, local_files: Set[str], s3_objects: Set[str]
+    ) -> List[str]:
+        deleted: List[str] = []
+        base = self.config.db_root
+        for rel in local_files - s3_objects:
+            try:
+                os.remove(os.path.join(base, rel))
+                deleted.append(rel)
+            except FileNotFoundError:
+                pass
+        return deleted

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,4 +13,5 @@ dependencies = [
     "watchdog>=2.1.0",
     "pyyaml>=6.0",
     "click>=8.0.0",
+    "boto3>=1.28.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ streamlit>=1.28.0
 watchdog>=2.1.0
 pyyaml>=6.0
 click>=8.0.0
+boto3>=1.28.0

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "pyarrow>=8.0.0",
         "click>=8.0.0",
         "pyyaml>=6.0",
+        "boto3>=1.28.0",
     ],
     extras_require={
         "dev": [

--- a/tests/test_s3_sync.py
+++ b/tests/test_s3_sync.py
@@ -1,0 +1,80 @@
+import io
+import sys
+from pathlib import Path
+from typing import Dict
+
+import boto3
+import pytest
+
+# Ensure package root on path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from flashduck.config import Config
+from flashduck.s3_sync import S3SyncManager
+
+
+class FakeS3Client:
+    """Very small in-memory mock of S3."""
+
+    def __init__(self) -> None:
+        self.objects: Dict[str, bytes] = {}
+
+    def list_objects_v2(self, Bucket, ContinuationToken=None):  # noqa: N802
+        contents = [{"Key": k} for k in sorted(self.objects.keys())]
+        return {"Contents": contents, "IsTruncated": False}
+
+    def put_object(self, Bucket, Key, Body):  # noqa: N802
+        data = Body.read() if hasattr(Body, "read") else Body
+        self.objects[Key] = data
+        return {"ResponseMetadata": {"HTTPStatusCode": 200}}
+
+    def get_object(self, Bucket, Key):  # noqa: N802
+        return {"Body": io.BytesIO(self.objects[Key])}
+
+
+@pytest.fixture
+def fake_s3(monkeypatch):
+    client = FakeS3Client()
+
+    def factory(service_name, **kwargs):
+        assert service_name == "s3"
+        return client
+
+    monkeypatch.setattr(boto3, "client", factory)
+    return client
+
+
+def test_s3_sync_cycle(tmp_path, fake_s3):
+    # remote object to be downloaded
+    fake_s3.objects["remote.txt"] = b"remote data"
+
+    db_root = tmp_path / "db"
+    pending = db_root / "pending"
+    db_root.mkdir()
+    pending.mkdir()
+
+    # create pending upload
+    (pending / "upload.txt").write_text("upload data")
+    # create stale file that should be deleted
+    (db_root / "stale.txt").write_text("stale")
+
+    config = Config(
+        db_root=str(db_root),
+        pending_writes_dir=str(pending),
+        s3_bucket="bucket",
+    )
+
+    mgr = S3SyncManager(config)
+    mgr.start()
+
+    # Upload occurred
+    assert fake_s3.objects["upload.txt"] == b"upload data"
+    assert "upload.txt" in mgr.upload_status()["uploaded"]
+
+    # Download occurred
+    assert (db_root / "remote.txt").read_text() == "remote data"
+    assert "remote.txt" in mgr.download_status()["downloaded"]
+
+    # Stale file deleted
+    assert not (db_root / "stale.txt").exists()
+    assert "stale.txt" in mgr.download_status()["deleted"]


### PR DESCRIPTION
## Summary
- add S3SyncManager using boto3 for listing, upload, download, and cleanup
- expose S3 credentials and bucket settings in Config
- include boto3 dependency and tests for S3 syncing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae264180e88332be876229d1e321df