### PR TITLE
Add default local drive sync backend

### DIFF
--- a/flashduck/__init__.py
+++ b/flashduck/__init__.py
@@ -7,6 +7,7 @@ from .parquet_writer import ParquetWriter
 from .file_monitor import FileMonitor
 from .config import Config
 from .sync_base import SyncBase
+from .local_drive_sync import LocalDriveSyncManager  # Default sync provider
 from .smb_sync_manager import SMBSyncManager
 from .azure_sync import (
     upload_loop,
@@ -30,6 +31,7 @@ __all__ = [
     "FileMonitor",
     "Config",
     "SyncBase",
+    "LocalDriveSyncManager",
     "SMBSyncManager",
     "upload_loop",
     "download_loop",

--- a/flashduck/local_drive_sync.py
+++ b/flashduck/local_drive_sync.py
@@ -1,0 +1,75 @@
+"""Local disk implementation of the SyncBase interface."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from typing import Any, Dict, List, Optional
+
+from .sync_base import SyncBase
+
+
+class LocalDriveSyncManager(SyncBase):
+    """Synchronize files using a local directory as the backend.
+
+    This manager mirrors the behaviour of cloud-based sync providers but
+    operates entirely on the local filesystem. It allows the package to have a
+    drop-in default implementation without requiring external services.
+    """
+
+    def __init__(self, root_path: str) -> None:
+        self.root_path = root_path
+        self._running = False
+        self._upload_info: Dict[str, Any] = {}
+        self._download_info: Dict[str, Any] = {}
+
+    def start(self) -> None:  # pragma: no cover - thin wrapper
+        """Mark the manager as running."""
+        self._running = True
+
+    def stop(self) -> None:  # pragma: no cover - thin wrapper
+        """Mark the manager as stopped."""
+        self._running = False
+
+    def upload_status(self) -> Dict[str, Any]:
+        """Return information about the last upload."""
+        return {"running": self._running, **self._upload_info}
+
+    def download_status(self) -> Dict[str, Any]:
+        """Return information about the last download."""
+        return {"running": self._running, **self._download_info}
+
+    def list_files(self) -> List[str]:
+        """List relative file paths under ``root_path``."""
+        files: List[str] = []
+        for dirpath, _, filenames in os.walk(self.root_path):
+            for name in filenames:
+                full = os.path.join(dirpath, name)
+                rel = os.path.relpath(full, self.root_path)
+                files.append(rel.replace(os.sep, "/"))
+        return files
+
+    def upload_file(self, local_path: str, remote_path: Optional[str] = None) -> None:
+        """Copy ``local_path`` into the managed directory."""
+        remote_path = remote_path or os.path.basename(local_path)
+        dest = os.path.join(self.root_path, remote_path)
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        shutil.copy2(local_path, dest)
+        self._upload_info = {"source": local_path, "destination": dest}
+
+    def download_file(self, remote_path: str, local_path: str) -> None:
+        """Copy ``remote_path`` from the managed directory to ``local_path``."""
+        src = os.path.join(self.root_path, remote_path)
+        os.makedirs(os.path.dirname(local_path), exist_ok=True)
+        shutil.copy2(src, local_path)
+        self._download_info = {"source": src, "destination": local_path}
+
+    def delete_file(self, remote_path: str) -> None:
+        """Delete ``remote_path`` from the managed directory if it exists."""
+        try:
+            os.remove(os.path.join(self.root_path, remote_path))
+        except FileNotFoundError:
+            pass
+
+
+__all__ = ["LocalDriveSyncManager"]

--- a/tests/test_local_drive_sync.py
+++ b/tests/test_local_drive_sync.py
@@ -1,0 +1,31 @@
+import os
+from flashduck.local_drive_sync import LocalDriveSyncManager
+
+
+def test_local_drive_sync_cycle(tmp_path):
+    remote = tmp_path / "remote"
+    remote.mkdir()
+
+    mgr = LocalDriveSyncManager(str(remote))
+    mgr.start()
+
+    # Upload a file into remote directory
+    src = tmp_path / "src.txt"
+    src.write_text("hello")
+    mgr.upload_file(str(src), "uploaded.txt")
+    assert (remote / "uploaded.txt").read_text() == "hello"
+    assert mgr.upload_status()["destination"].endswith("uploaded.txt")
+
+    # List files
+    files = mgr.list_files()
+    assert "uploaded.txt" in files
+
+    # Download the file to a new location
+    dest = tmp_path / "downloaded.txt"
+    mgr.download_file("uploaded.txt", str(dest))
+    assert dest.read_text() == "hello"
+    assert mgr.download_status()["source"].endswith("uploaded.txt")
+
+    # Delete the file from the remote directory
+    mgr.delete_file("uploaded.txt")
+    assert not (remote / "uploaded.txt").exists()


### PR DESCRIPTION
## Summary
- provide `LocalDriveSyncManager` for simple filesystem-based syncing
- expose local drive sync as the default sync provider
- test local drive sync operations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae5fbf507c8332a420d94eddd53c42